### PR TITLE
Add XPack authentication support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,11 +13,14 @@ lazy val elastic4play = (project in file("."))
 
 scalaVersion := "2.12.4"
 
+resolvers += "elasticsearch-releases" at "https://artifacts.elastic.co/maven"
+
 libraryDependencies ++= Seq(
   cacheApi,
   "com.sksamuel.elastic4s" %% "elastic4s-core" % "5.6.0",
   "com.sksamuel.elastic4s" %% "elastic4s-streams" % "5.6.0",
   "com.sksamuel.elastic4s" %% "elastic4s-tcp" % "5.6.0",
+  "com.sksamuel.elastic4s" %% "elastic4s-xpack-security" % "5.6.0",
   "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.6" % Test,
   "org.scalactic" %% "scalactic" % "3.0.4",
   "org.bouncycastle" % "bcprov-jdk15on" % "1.58",


### PR DESCRIPTION
The elastic4play framework does not currently support authentication enabled on the ElasticSearch database enabled through the XPack component (cf CERT-BDF/TheHive#384).

Hopefully, this PR should add the feature. Setting the `search.username` (at least) and the `search.password` configuration directives will trigger the use of the XPack client. Otherwise, the current TCP client is used.

Unfortunately, I am not in position to test it thoroughly but executing `sbt clean compile` ends successfully and executing `sbt test` throws the same errors as the master branch.

Please let me know if this doesn't match your standards.